### PR TITLE
Dev 5.1.8

### DIFF
--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -137,7 +137,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "5.1.7"
+    VERSION = "5.1.8"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -2,13 +2,14 @@ import sys
 import json
 import re
 import os
+import requests
 import numpy as np
 import pandas as pd
 from nse import NSE
 from pathlib import Path
 from datetime import datetime, timedelta
 from defs.Config import Config
-from typing import cast, Any, Dict, List, Optional
+from typing import cast, Any, Dict, List, Optional, Tuple
 
 
 class Dates:
@@ -82,6 +83,21 @@ def getMuhuratHolidayInfo(holidays: Dict[str, List[dict]]) -> dict:
                 return dct
 
     return {}
+
+
+def downloadSpecialSessions() -> Tuple[datetime, ...]:
+    base_url = "https://raw.githubusercontent.com/BennyThadikaran/eod2_data"
+
+    res = requests.get(f"{base_url}/main/special_sessions.txt")
+
+    if res.ok:
+        return tuple(
+            datetime.fromisoformat(x) for x in res.text.strip().split("\n")
+        )
+
+    raise ConnectionError(
+        f"special_sessions.txt download failed. {res.status_code}: {res.reason}"
+    )
 
 
 def getHolidayList(nse: NSE):

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -117,7 +117,7 @@ def getHolidayList(nse: NSE):
     return data
 
 
-def checkForHolidays(nse: NSE):
+def checkForHolidays(nse: NSE, special_sessions: Tuple[datetime, ...]):
     """Returns True if current date is a holiday.
     Exits the script if today is a holiday"""
 
@@ -127,11 +127,12 @@ def checkForHolidays(nse: NSE):
     curDt = dates.dt.strftime("%d-%b-%Y")
     isToday = curDt == dates.today.strftime("%d-%b-%Y")
 
+    if dates.dt in special_sessions:
+        return False
+
     # no holiday list or year has changed or today is a holiday
     if (
-        dates.dt == datetime(2024, 1, 22)
-        or dates.dt == datetime(2024, 3, 2)
-        or "holidays" not in meta
+        "holidays" not in meta
         or meta["year"] != dates.dt.year
         or (curDt in meta["holidays"] and not hasLatestHolidays)
     ):

--- a/src/init.py
+++ b/src/init.py
@@ -32,6 +32,9 @@ if args.version:
 if args.config:
     exit(str(defs.config))
 
+# download the latest special_sessions.txt from eod2_data repo
+special_sessions = defs.downloadSpecialSessions()
+
 nse = NSE(defs.DIR)
 
 if defs.config.AMIBROKER and not defs.isAmiBrokerFolderUpdated():
@@ -52,7 +55,7 @@ while True:
         nse.exit()
         exit()
 
-    if defs.checkForHolidays(nse):
+    if defs.checkForHolidays(nse, special_sessions):
         continue
 
     # Validate NSE actions file

--- a/tests/test_defs.py
+++ b/tests/test_defs.py
@@ -86,7 +86,7 @@ class TestCheckForHolidays(unittest.TestCase):
 
         # Call the function
         with patch.object(defs, "meta", meta_obj):
-            result = defs.checkForHolidays(mock_nse)
+            result = defs.checkForHolidays(mock_nse, tuple())
 
         self.assertFalse(result)
         mock_get_holiday_list.assert_not_called()
@@ -101,7 +101,7 @@ class TestCheckForHolidays(unittest.TestCase):
 
         # Call the function
         with patch.object(defs, "meta", {"holidays": {}, "year": 2023}):
-            result = defs.checkForHolidays(mock_nse)
+            result = defs.checkForHolidays(mock_nse, tuple())
 
         self.assertTrue(result)
         mock_get_holiday_list.assert_not_called()
@@ -119,7 +119,7 @@ class TestCheckForHolidays(unittest.TestCase):
 
         # Call the function
         with patch.object(defs, "meta", {}):
-            result = defs.checkForHolidays(mock_nse)
+            result = defs.checkForHolidays(mock_nse, tuple())
 
         # Assertions
         self.assertFalse(result)
@@ -145,7 +145,7 @@ class TestCheckForHolidays(unittest.TestCase):
         mock_get_holiday_list.return_value = holiday_obj
 
         with patch.object(defs, "meta", meta_obj):
-            result = defs.checkForHolidays(mock_nse)
+            result = defs.checkForHolidays(mock_nse, tuple())
 
         self.assertTrue(result)
         mock_get_holiday_list.assert_called_once()
@@ -169,9 +169,22 @@ class TestCheckForHolidays(unittest.TestCase):
 
         with patch.object(defs, "meta", meta_obj):
             with self.assertRaises(SystemExit):
-                defs.checkForHolidays(mock_nse)
+                defs.checkForHolidays(mock_nse, tuple())
 
         mock_get_holiday_list.assert_called_once()
+
+    @patch.object(defs, "dates")
+    def test_is_special_session(self, _):
+        dt = datetime(2024, 3, 16)
+        defs.dates.dt = defs.dates.today = dt
+
+        # Mock NSE class
+        mock_nse = Mock()
+
+        # Call the function
+        result = defs.checkForHolidays(mock_nse, (dt,))
+
+        self.assertFalse(result)
 
 
 class TestValidateNseActionsFile(unittest.TestCase):


### PR DESCRIPTION
This update removes hard coded dates for [NSE Disaster Recovery (DR) sessions](https://www.nseindia.com/trade/disaster-recovery-faqs) which are held on Saturdays.

**EOD2 users are no longer required to pull updates everytime DR sessions are announced.**

Dates are now stored in special_sessions.txt on [eod2_data](https://github.com/BennyThadikaran/eod2_data) repo and are automatically downloaded by the script on every sync.