### PR TITLE
Dev v6.0.1

### DIFF
--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -138,7 +138,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "6.0.0"
+    VERSION = "6.0.1"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -404,16 +404,13 @@ def updateAmiBrokerRecords(nse: NSE):
         if dt.weekday() > 4:
             continue
 
-        bhavFile = (
-            DIR
-            / "nseBhav"
-            / str(dt.year)
-            / f"BhavCopy_NSE_CM_0_0_0_{dt:%Y%m%d}_F_0000.csv"
-        )
+        bhavFolder = DIR / "nseBhav" / str(dt.year)
+        bhavFile = bhavFolder / f"BhavCopy_NSE_CM_0_0_0_{dt:%Y%m%d}_F_0000.csv"
 
         if not bhavFile.exists():
             try:
                 bhavFile = nse.equityBhavcopy(dt)
+                bhavFile.rename(bhavFolder / bhavFile.name)
             except (RuntimeError, FileNotFoundError):
                 continue
             except ChunkedEncodingError as e:
@@ -421,8 +418,6 @@ def updateAmiBrokerRecords(nse: NSE):
                 exit()
 
         toAmiBrokerFormat(bhavFile)
-
-        bhavFile.unlink()
 
         daysComplete = totalDays - (lastUpdate - dt).days
         pctComplete = int(daysComplete / totalDays * 100)


### PR DESCRIPTION
Previously when syncing Amibroker folder for first time, existing and previously downloaded bhavcopies were getting deleted. This fixes the issue and downloaded bhavcopy is moved to `src/nseBhav` folder

- No deleting of bhavcopy files during Amibroker folder sync.
- Move bhavcopy to nseBhav folder during Amibroker folder sync.
- Bump version to 6.0.1