### PR TITLE
Fixes warning - Renaming daily/ambaniorg.csv to ambaniorgo.csv. No such file.

### DIFF
--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -138,7 +138,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "6.0.3"
+    VERSION = "6.0.4"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -562,8 +562,8 @@ def updateNseEOD(bhavFile: Path, deliveryFile: Optional[Path]):
 
             isin.at[t.Index, "SYMBOL"] = t.TckrSymb
 
-            SYM_FILE = DAILY_FOLDER / f"{new}.csv"
-            OLD_FILE = DAILY_FOLDER / f"{old}.csv"
+            SYM_FILE = DAILY_FOLDER / f"{new}{prefix}.csv"
+            OLD_FILE = DAILY_FOLDER / f"{old}{prefix}.csv"
 
             try:
                 OLD_FILE.rename(SYM_FILE)


### PR DESCRIPTION
WARNING: Renaming daily/ambaniorg.csv to ambaniorgo.csv. No such file.

- Fix: Add prefix during name change operations on SME stocks.
- Bump version to 6.0.4