### PR TITLE
Dev v7.0.0

### DIFF
--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -85,7 +85,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "6.0.5"
+    VERSION = "7.0.0"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
 DIR = Path(__file__).parents[1]
 
@@ -7,124 +7,71 @@ DIR = Path(__file__).parents[1]
 class Config:
     """A class to store all configuration related to EOD2
 
-    Attributes for AMIBROKER
-        AMIBROKER:              If True, converts bhavcopy to Amibroker format on
-                                sync. Data is stored in src/eod2_data/amibroker/
-                                Default False.
-
-        AMI_UPDATE_DAYS:        Number of days bhavcopy must be downloaded and
-                                formated to Amibroker.
-                                Only applies if src/eod2_data/amibroker/ is empty.
-                                Default 365.
-
-        DLV_L1,L2,L3            This is a multiple of average delivery.
-                                L3 being highest delivery multiple
-
-        DLV_AVG_LEN:            Length used to calculate delivery average.
-                                Default 60.
-
-        VOL_AVG_LEN             Length used to calculate volume average.
-                                Default 30
-
-    Attributes for plot.py
-        PLOT_PLUGINS:           A dictionary of plugins to load. Dict values
-                                must be a dictionary containing plugin
-                                configuration.
-
-        PLOT_DAYS:              Number of days to be plotted with plot.py.
-                                Default 160.
-
-        PLOT_WEEKS:             Number of weeks to be plotted with plot.py.
-                                Default 140.
-
-        PLOT_M_RS_LEN_D:        Length used to calculate Mansfield
-                                Relative Strength on daily TF. Default 60.
-
-        PLOT_M_RS_LEN_W:        Length used to calculate Mansfield
-                                Relative Strength on Weekly TF. Default 52.
-
-        PLOT_RS_INDEX:          Index used to calculate Dorsey Relative strength
-                                and Mansfield relative strength.
-                                Default 'nifty 50'
-
-        MAGNET_MODE:            When True, lines snap to closest High, Low,
-                                Close or Open. If False, mouse click coordinates on
-                                chart are used.
-                                Default True
-
-        PLOT_CHART_STYLE:       Chart theme
-        PLOT_CHART_TYPE:        Chart type. One of: ohlc, candle, line
-
-        PLOT_RS_COLOR:          Dorsey RS line color
-        PLOT_M_RS_COLOR:        Mansfield RS line color
-        PLOT_DLV_L1_COLOR:      Delivery mode L1 bar color
-        PLOT_DLV_L2_COLOR:      Delivery mode L2 bar color
-        PLOT_DLV_L3_COLOR:      Delivery mode L3 bar color
-        PLOT_DLV_DEFAULT_COLOR: Delivery mode default color
-
-    Attributes for DGET.py
-        DGET_DAYS:            Number of days delivery analysis to return.
-                                Default 15.
-
-        DGET_AVG_DAYS:        Number of days average to calculate above average
-                                delivery. Default 60.
-
     To override the attributes of this class, create a user.json file in
     src/defs/ with the option you wish to override.
 
     All key attributes in user.json must be uppercase.
     """
 
-    AMIBROKER = False
-    AMI_UPDATE_DAYS = 365
     INIT_HOOK = None
 
-    # Delivery
-    DLV_L1 = 1
-    DLV_L2 = 1.5
-    DLV_L3 = 2
-    DLV_AVG_LEN = 60
-    VOL_AVG_LEN = 30
+    ## AMIBROKER ##
+    AMIBROKER = False  # converts to Amibroker format on sync
+    AMI_UPDATE_DAYS = 365  # Number of days to convert on first run
 
-    # DGET
-    DGET_AVG_DAYS = 60
-    DGET_DAYS = 15
+    ## Delivery ##
+    DLV_L1 = 1  # 1x average delivery
+    DLV_L2 = 1.5  # 1.5x average delivery
+    DLV_L3 = 2  # 2x average delivery
+    DLV_AVG_LEN = 30  # Length used to calculate delivery average.
+    VOL_AVG_LEN = 30  # Length used to calculate volume average.
 
-    # PLOT CONFIG
-    PLOT_PLUGINS = {}
-    PLOT_DAYS = 160
-    PLOT_WEEKS = 140
-    PLOT_M_RS_LEN_D = 22
-    PLOT_M_RS_LEN_W = 52
-    PLOT_RS_INDEX = "nifty 50"
+    ## DGET.py ##
+    DGET_AVG_DAYS = 30  # Length used to calculate avg vol, trade qty, delivery
+    DGET_DAYS = 30  # No of days delivery result returned with -l option
+
+    ## PLOT CONFIG ##
+
+    # snap lines drawn to nearest high/Low/close/open.
+    # Use mouse coordinates if false.
     MAGNET_MODE = True
 
-    PRESET = {}
-    WATCH = {"SECTORS": "sectors.csv"}
+    PLOT_PLUGINS = {}  # Key is plugin name, Value is a dict of plugin config.
+    PLOT_DAYS = 160  # No of days to plot
+    PLOT_WEEKS = 140  # No of weeks to plot
 
-    # PLOT THEMES AND COLORS
-    # 'binance', 'binancedark', 'blueskies', 'brasil', 'charles',
-    # 'checkers', 'classic', 'default', 'ibd', 'kenan', 'mike',
-    # 'nightclouds', 'sas', 'starsandstripes', 'tradingview', 'yahoo'
-    PLOT_CHART_STYLE = "tradingview"
+    # Mansfield Relative Strength (MRS) and # Dorsey Relative Strength (RS)
+    PLOT_M_RS_LEN_D = 22  # Daily length
+    PLOT_M_RS_LEN_W = 52  # Weekly length
+    PLOT_RS_INDEX = "nifty 50"  # Nifty index to use for RS and MRS
 
-    # ohlc, candle, line
-    PLOT_CHART_TYPE = "candle"
+    # One of binance, binancedark, blueskies, brasil, charles, checkers,
+    # classic, default, ibd, kenan, mike, nightclouds, sas, starsandstripes,
+    # tradingview, yahoo
+    PLOT_CHART_STYLE = "tradingview"  # Chart theme
 
+    PLOT_CHART_TYPE = "candle"  # ohlc, candle, line
+
+    # Chart colors
     # https://matplotlib.org/stable/gallery/color/named_colors.html#base-colors
-    PLOT_RS_COLOR = "darkblue"
-    PLOT_M_RS_COLOR = "darkgreen"
-    PLOT_DLV_L1_COLOR = "red"
-    PLOT_DLV_L2_COLOR = "darkorange"
-    PLOT_DLV_L3_COLOR = "royalblue"
-    PLOT_DLV_DEFAULT_COLOR = "darkgrey"
+    PLOT_RS_COLOR = "darkblue"  # Dorsey Relative Strength line
+    PLOT_M_RS_COLOR = "darkgreen"  # Mansfield Relative Strength line
 
-    PLOT_AXHLINE_COLOR = "crimson"
-    PLOT_TLINE_COLOR = "darkturquoise"
-    PLOT_ALINE_COLOR = "mediumseagreen"
-    PLOT_HLINE_COLOR = "royalblue"
+    # Delivery - Candle colors
+    PLOT_DLV_DEFAULT_COLOR = "darkgrey"  # default color
+    PLOT_DLV_L1_COLOR = "red"  # level 1
+    PLOT_DLV_L2_COLOR = "darkorange"  # level 2
+    PLOT_DLV_L3_COLOR = "royalblue"  # level 3
 
+    # Trendline, horizontal line colors
+    PLOT_AXHLINE_COLOR = "crimson"  # horizontal line (end to end)
+    PLOT_HLINE_COLOR = "royalblue"  # horizontal line (from set point to end)
+    PLOT_TLINE_COLOR = "darkturquoise"  # Trend line
+    PLOT_ALINE_COLOR = "mediumseagreen"  # Arbitrary line (segment)
+
+    WATCH = {"SECTORS": (DIR / "data/sectors.csv").resolve()}
     ADDITIONAL_INDICES = []
+    PRESET = {}
 
     def __init__(self) -> None:
         user_config = DIR / "defs" / "user.json"

--- a/src/defs/Plotter.py
+++ b/src/defs/Plotter.py
@@ -884,25 +884,29 @@ class Plotter:
         exit(f"Preset '{preset}' removed.")
 
     def _loadWatchList(self, watch):
-        if watch.upper() not in self.config.WATCH:
+        watch = watch.upper()
+        if watch not in self.config.WATCH:
             exit(f"Error: No watchlist named '{watch}'")
 
-        file = self.DIR / "data" / self.config.WATCH[watch.upper()]
+        file = Path(self.config.WATCH[watch]).expanduser()
 
         if not file.is_file():
+            print(self.config.WATCH[watch])
             exit(f"Error: File not found {file}")
 
         return file.read_text().strip("\n").split("\n")
 
-    def _addWatch(self, name, fName):
+    def _addWatch(self, name, fpath: str):
         data = loadJson(self.configPath) if self.configPath.is_file() else {}
 
         if "WATCH" not in data:
             data["WATCH"] = {}
 
-        data["WATCH"][name.upper()] = fName
+        fpath = str(Path(fpath).resolve())
+
+        data["WATCH"][name.upper()] = fpath
         writeJson(self.configPath, data)
-        exit(f"Added watchlist '{name}' with value '{fName}'")
+        exit(f"Added watchlist '{name}' with value '{fpath}'")
 
     def _removeWatch(self, name):
         if name.upper() not in getattr(self.config, "WATCH"):

--- a/src/defs/Plotter.py
+++ b/src/defs/Plotter.py
@@ -16,6 +16,7 @@ from defs.utils import (
     getDataFrame,
     getDeliveryLevels,
     getLevels,
+    getLevels_v2,
     loadJson,
     manfieldRelativeStrength,
     randomChar,

--- a/src/defs/Plotter.py
+++ b/src/defs/Plotter.py
@@ -641,10 +641,18 @@ class Plotter:
             )
 
         if self.args.snr:
-            mean_candle_size = (df["High"] - df["Low"]).mean()
+            mean_candle_size = (df["High"] - df["Low"]).median()
 
             self.plot_args["alines"] = {
                 "alines": getLevels(df, mean_candle_size),
+                "linewidths": 0.7,
+            }
+
+        if self.args.snr_v2:
+            mean_candle_size = (df["High"] - df["Low"]).median()
+
+            self.plot_args["alines"] = {
+                "alines": getLevels_v2(df, mean_candle_size),
                 "linewidths": 0.7,
             }
 

--- a/src/defs/Plotter.py
+++ b/src/defs/Plotter.py
@@ -1,25 +1,27 @@
-import pandas as pd
 import pickle
-import numpy as np
-import mplfinance as mpl
-import matplotlib.pyplot as plt
-from pathlib import Path
 from datetime import timedelta
-from matplotlib.collections import LineCollection
+from functools import lru_cache
+from pathlib import Path
+
 import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
+import mplfinance as mpl
+import numpy as np
+import pandas as pd
+from matplotlib.collections import LineCollection
+
 from defs.utils import (
     arg_parse_dict,
     getDataFrame,
-    getLevels,
     getDeliveryLevels,
-    writeJson,
+    getLevels,
     loadJson,
+    manfieldRelativeStrength,
     randomChar,
     relativeStrength,
-    manfieldRelativeStrength,
+    writeJson,
 )
-from functools import lru_cache
 
 HELP = """                                           ## Help ##
 

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -29,38 +29,24 @@ if not hasattr(NSE, "__version__"):
     exit(f"nse package need to be updated\nRun: {pip} install -U nse")
 
 
-def configure_logger(name: str) -> logging.Logger:
+def configure_logger():
     """Return a logger instance by name
 
     Creates a file handler to log messages with level WARNING and above
 
     Creates a stream handler to log messages with level INFO and above
-
-    Parameters:
-    name (str): Pass __name__ for module level logger
     """
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
-
-    stdout_handler = logging.StreamHandler()
-    stdout_handler.setLevel(logging.INFO)
-
-    stdout_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-
+    stream_handler = logging.StreamHandler()
     file_handler = logging.FileHandler(DIR / "error.log")
+
     file_handler.setLevel(logging.WARNING)
 
-    file_handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
+    logging.basicConfig(
+        format="%(levelname)s: %(asctime)s - %(name)s - %(message)s",
+        datefmt="%d-%m-%Y %H:%M",
+        level=logging.INFO,
+        handlers=(stream_handler, file_handler),
     )
-
-    logger.addHandler(stdout_handler)
-    logger.addHandler(file_handler)
-
-    return logger
 
 
 def load_module(module_str: str) -> Union[ModuleType, Type]:
@@ -1005,7 +991,9 @@ if __name__ != "__main__":
         b"Date,Open,High,Low,Close,Volume,TOTAL_TRADES,QTY_PER_TRADE,DLV_QTY\n"
     )
 
-    logger = configure_logger(__name__)
+    configure_logger()
+
+    logger = logging.getLogger(__name__)
 
     tz_local = tzlocal.get_localzone()
     tz_IN = ZoneInfo("Asia/Kolkata")

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -1,20 +1,22 @@
-import sys
+import importlib.util
 import json
-import re
-import os
-import requests
 import logging
+import os
+import re
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, List, Optional, Tuple, Type, Union
+from zoneinfo import ZoneInfo
+
 import numpy as np
 import pandas as pd
-import importlib.util
-from zoneinfo import ZoneInfo
-from requests.exceptions import ChunkedEncodingError
+import requests
 from nse import NSE
-from pathlib import Path
-from datetime import datetime, timedelta
+from requests.exceptions import ChunkedEncodingError
+
 from defs.Config import Config
-from typing import Dict, List, Optional, Tuple, Union, Type
-from types import ModuleType
 
 pip = "pip" if "win" in sys.platform else "pip3"
 

--- a/src/defs/utils.py
+++ b/src/defs/utils.py
@@ -1,12 +1,13 @@
+import io
 import json
 import os
-import io
-import pandas as pd
-import string
 import random
+import string
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Tuple, Optional
+from typing import Any, List, Optional, Tuple
+
+import pandas as pd
 
 
 class DateEncoder(json.JSONEncoder):

--- a/src/defs/utils.py
+++ b/src/defs/utils.py
@@ -363,6 +363,61 @@ def getLevels(
     return alines
 
 
+def isFarFromLevel_v2(
+    level: float,
+    levels: List[Tuple[pd.Timestamp, float]],
+    mean_candle_size: float,
+):
+    """Returns true if difference between the level and any of the price levels
+    is greater than the mean_candle_size."""
+    # Detection of price support and resistance levels in Python -Gianluca Malato
+    # source: https://towardsdatascience.com/detection-of-price-support-and-resistance-levels-in-python-baedc44c34c9
+    return sum([abs(level - x[1]) < mean_candle_size for x in levels]) == 0
+
+
+def getLevels_v2(df: pd.DataFrame, mean_candle_size: float):
+
+    levels = []
+
+    highs_mask = (
+        (df.High.shift(1) < df.High)
+        & (df.High.shift(2) < df.High)
+        & (df.High.shift(3) < df.High)
+        & (df.High.shift(-1) < df.High)
+        & (df.High.shift(-2) < df.High)
+        & (df.High.shift(-3) < df.High)
+    )
+
+    lows_mask = (
+        (df.Low.shift(1) > df.Low)
+        & (df.Low.shift(2) > df.Low)
+        & (df.Low.shift(3) > df.Low)
+        & (df.Low.shift(-1) > df.Low)
+        & (df.Low.shift(-2) > df.Low)
+        & (df.Low.shift(-3) > df.Low)
+    )
+
+    # filter for rejection from top
+    # 2 succesive highs followed by 2 succesive lower highs
+    max = df["High"].loc[highs_mask].dropna()
+    min = df["Low"].loc[lows_mask].dropna()
+
+    max_min = pd.concat([max, min], axis=0)
+
+    max_min = max_min.loc[~max_min.index.duplicated()]
+
+    for i, lv in max_min.items():
+
+        touch_count = max_min.loc[
+            (max_min - lv).abs() < mean_candle_size
+        ].count()
+
+        if touch_count > 1 and isFarFromLevel_v2(lv, levels, mean_candle_size):
+            levels.append((i, lv))
+
+    return [((i, lv), (df.index[-1], lv)) for i, lv in levels]
+
+
 # def getScreenSize():
 #     root = Tk()
 #     root.withdraw()

--- a/src/init.py
+++ b/src/init.py
@@ -1,9 +1,11 @@
+import logging
 import sys
-from defs.utils import writeJson
-from defs import defs
 from argparse import ArgumentParser
+
 from nse import NSE
 
+from defs import defs
+from defs.utils import writeJson
 
 logger = defs.configure_logger(__name__)
 

--- a/src/init.py
+++ b/src/init.py
@@ -141,7 +141,9 @@ while True:
         defs.hook.on_complete()
 
     defs.cleanup((BHAV_FILE, DELIVERY_FILE, INDEX_FILE))
-    defs.cleanOutDated()
+
+    if defs.dates.today == defs.dates.dt:
+        defs.cleanOutDated()
 
     defs.meta["lastUpdate"] = defs.dates.lastUpdate = defs.dates.dt
     writeJson(defs.META_FILE, defs.meta)

--- a/src/init.py
+++ b/src/init.py
@@ -7,7 +7,7 @@ from nse import NSE
 from defs import defs
 from defs.utils import writeJson
 
-logger = defs.configure_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Set the sys.excepthook to the custom exception handler
 sys.excepthook = defs.log_unhandled_exception

--- a/src/plot.py
+++ b/src/plot.py
@@ -121,6 +121,12 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--snr-v2",
+    action="store_true",
+    help="Add Support and Resistance lines on chart",
+)
+
+parser.add_argument(
     "-r",
     "--resume",
     action="store_true",

--- a/src/plot.py
+++ b/src/plot.py
@@ -1,10 +1,11 @@
-from defs.Plotter import Plotter, processPlot
-from defs.utils import loadJson, writeJson
-from defs.Config import Config
-from defs.Plugin import Plugin
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
+
+from defs.Config import Config
+from defs.Plotter import Plotter, processPlot
+from defs.Plugin import Plugin
+from defs.utils import loadJson, writeJson
 
 DIR = Path(__file__).parent
 config = Config()


### PR DESCRIPTION
## Breaking Changes
Prior to version 7, `--watch-add` accepted a file-path mapped to `eod2/src/data`. Going forward file-path can be anywhere on the filesystem. Existing `user.json` will need to be updated with full file-path to avoid `file not found errors`.

## New Features
Plot.py has a new CLI option, `--snr-v2` which plots support and resistance with multiple touches or price rejections.

**Improved performance when syncing multiple days** by calling function `defs.cleanOutDated` once on the final day. 

## Changes
https://github.com/BennyThadikaran/eod2/commit/21855b4512ce8bb08fb65d5060da7dbb15d961f1 (HEAD -> dev) Bump to version 7.0.0

https://github.com/BennyThadikaran/eod2/commit/726620e488b3fda3fa740a058237686bb96129e7

- FEAT: Added support for multitouch support and resistance.
- Both --snr and --snr-v2 use median average instead of mean.

https://github.com/BennyThadikaran/eod2/commit/15a0b16beff26f0c5bda8dfaa80aafecb75e067e Added utility functions for multitouch support and resistance.

https://github.com/BennyThadikaran/eod2/commit/5e65ef6d08fc501fe7ac3e096e86d5f0126edc45 Added new cli option `--snr-v2`

https://github.com/BennyThadikaran/eod2/commit/15b32727ff6cff7c49011a20a7ade30d42575613, https://github.com/BennyThadikaran/eod2/commit/698dad8fd92cc8dbd5e7bf651be3988108765a71 Formatted import statements

https://github.com/BennyThadikaran/eod2/commit/3cb341a97e1f4e5b670a043be0a865ef61047f6a Fix: When syncing multiple days, run cleanOutDated only on last day.

https://github.com/BennyThadikaran/eod2/commit/925b65aba29dedc32446d8d681fb7d5b51fa555a

- Fix: Duplicate logs
- logger instances will reuse and inherit from root logger.

https://github.com/BennyThadikaran/eod2/commit/cb7eee5f0f3cc8aa9008dae008e83531c40d511e

- Rearranged Config class docstrings into inline comments
- `--watch-add` accepts a filepath anywhere on the filesystem.