### PR TITLE
Dev v7.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fast_csv_loader>=1.0.1
 mplfinance==0.12.10b0
 nse>=1.0.5
-pandas==2.2.2
+pandas==2.0.3
 requests==2.32.3
 tzlocal==5.2

--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -84,7 +84,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "7.0.9"
+    VERSION = "7.0.10"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -36,12 +36,20 @@ def configure_logger():
 
     file_handler.setLevel(logging.WARNING)
 
-    file_handler.setFormatter(
-        logging.Formatter(
-            "%(levelname)s: %(asctime)s - %(name)s - %(message)s - EOD2 v%(eod_v)s - NSE v%(nse_v)s - %(last_update)s",
-            defaults=meta_info,
+    try:
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(levelname)s: %(asctime)s - %(name)s - %(message)s - EOD2 v%(eod_v)s - NSE v%(nse_v)s - %(last_update)s",
+                defaults=meta_info,
+            )
         )
-    )
+    except TypeError:
+        # Python 3.8 and 3.9 - No support for defaults parameter.
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(levelname)s: %(asctime)s - %(name)s - %(message)s"
+            )
+        )
 
     logging.basicConfig(
         format="%(levelname)s: %(asctime)s - %(name)s - %(message)s",

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -661,7 +661,7 @@ def getBonus(sym, string):
 def makeAdjustment(
     symbol: str,
     adjustmentFactor: float,
-    prev_commit: Optional[dict[str, Union[pd.DataFrame, Path]]] = None,
+    prev_commit: Optional[Dict[str, Union[pd.DataFrame, Path]]] = None,
 ) -> Optional[Tuple[pd.DataFrame, Path]]:
     """Makes adjustment to stock data prior to ex date,
     returning a tuple of pandas pd.DataFrame and filename"""

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -8,7 +8,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from types import ModuleType
 from typing import Dict, List, Optional, Tuple, Type, Union
-from zoneinfo import ZoneInfo
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Resolved GH issue #207 Python 3.8 and 3.9 compatibility

c15492c93 (HEAD -> dev, tag: v7.0.10, origin/dev) Bump to version 7.0.10
b985701ee Fix: dict type is not subscriptable. Use typing.Dict for Python 3.8
066c284f4 Fix: TypeError in Logging.Formatter in Python 3.9 and lower
0f42f9e08 Added backports.zoneinfo for Python 3.8 and 3.9
ef3a96b59 Downgrade pandas to 2.0.3 for Python 3.8 compatibility