### PR TITLE
Dev v7.0.12

### DIFF
--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -84,7 +84,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "7.0.11"
+    VERSION = "7.0.12"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -574,7 +574,7 @@ def updateNseEOD(bhavFile: Path, deliveryFile: Optional[Path]):
                     f"Renaming daily/{old}.csv to {new}.csv. No such file."
                 )
 
-            logger.info(f"Name Changed: {old} to {new}")
+            logger.warning(f"Name Changed: {old} to {new}")
 
         updateNseSymbol(
             SYM_FILE,


### PR DESCRIPTION
47e0e10c2 (HEAD -> dev) Bump to version 7.0.12

dcd3509cb On symbol name change, log a warning instead of info.

    Logs with warning level and above are added to error.log.
    This change provides a historic reference for symbol name
    changes in the error.log file.