### PR TITLE
Changelog v8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 fast_csv_loader>=1.0.1
 mplfinance==0.12.10b0
-nse>=1.0.5
+nse[server]==1.2.2
 pandas==2.0.3; python_version == "3.8"
 pandas==2.2.2; python_version > "3.8"
-requests==2.32.3
 tzlocal==5.2

--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -84,7 +84,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "7.0.13"
+    VERSION = "8.0.0"
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/init.py
+++ b/src/init.py
@@ -36,7 +36,7 @@ if args.config:
 special_sessions = defs.downloadSpecialSessions()
 
 try:
-    nse = NSE(defs.DIR)
+    nse = NSE(defs.DIR, server=True)
 except (TimeoutError, ConnectionError) as e:
     logger.warning(
         f"Network error connecting to NSE - Please try again later. - {e!r}"


### PR DESCRIPTION
This update resolves timeout errors on HTTP1 requests by NSE
server by switching to HTTP2. see github issue #238 

All http requests are made using `httpx` library, instead of `requests`.

a2ab37a8a (HEAD -> dev) Updated eod2_data submodule

cec9fa0f7 Bump to version 8.0.0

f7ae0f8c4 Fix tests for additions of mf action downloads

fc2572925 Updated eod2 to use httpx instead of requests

a54fb6b3b Updated setup_data.py to use httpx instead of requests

fb27bde96 Upgraded nse package to server edition
