### PR TITLE
Dev v8.2.0

### DIFF
--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -85,6 +85,7 @@ class Config:
 
     # DO NOT EDIT BELOW
     VERSION = "8.1.3"
+    EXPECTED_DATA_VERSION = 1
 
     def toList(self, filename: str):
         return (DIR / "data" / filename).read_text().strip().split("\n")

--- a/src/defs/Config.py
+++ b/src/defs/Config.py
@@ -84,7 +84,7 @@ class Config:
             self.__dict__.update(dct)
 
     # DO NOT EDIT BELOW
-    VERSION = "8.1.3"
+    VERSION = "8.2.0"
     EXPECTED_DATA_VERSION = 1
 
     def toList(self, filename: str):

--- a/src/defs/Plotter.py
+++ b/src/defs/Plotter.py
@@ -231,6 +231,10 @@ class Plotter:
         if self.args.save:
             return df
 
+        if df.Open.hasnans:
+            for col in ("Open", "High", "Low"):
+                df[col] = df[col].fillna(df.Close)
+
         fig, axs = mpl.plot(df, **self.plot_args)
 
         # A workaround using ConciseDateFormatter and AutoDateLocator

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -921,9 +921,9 @@ def adjustNseStocks():
                     sym += "_sme"
 
                 if ("split" in purpose or "splt" in purpose) and ex == dtStr:
-                    i = purpose.index("split" if "split" in purpose else "splt")
-
                     error_context = f"{sym} - Split - {dtStr}"
+
+                    i = purpose.index("spl")
                     adjustmentFactor = getSplit(sym, purpose[i:])
 
                     if adjustmentFactor is None:

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -947,12 +947,15 @@ def adjustNseStocks():
                         post_commits.append((sym, adjustmentFactor))
                         logger.info(f"{sym}: {purpose}")
 
-                if (
-                    "bonus" in purpose
-                    and "deb" not in purpose
-                    and "pref" not in purpose
-                    and ex == dtStr
-                ):
+                if "bonus" in purpose and ex == dtStr:
+                    if (
+                        "deb" in purpose
+                        or "pref" in purpose
+                        or "ncrps" in purpose
+                        or "dvr" in purpose
+                    ):
+                        continue
+
                     error_context = f"{sym} - Bonus - {dtStr}"
                     adjustmentFactor = getBonus(sym, purpose)
 

--- a/src/defs/defs.py
+++ b/src/defs/defs.py
@@ -927,6 +927,9 @@ def adjustNseStocks():
                     adjustmentFactor = getSplit(sym, purpose[i:])
 
                     if adjustmentFactor is None:
+                        logger.warning(
+                            f"Possible adjustment failure: SPLIT - {sym} - {purpose} - exDate: {dtStr}"
+                        )
                         continue
 
                     commit = makeAdjustment(
@@ -954,6 +957,9 @@ def adjustNseStocks():
                     adjustmentFactor = getBonus(sym, purpose)
 
                     if adjustmentFactor is None:
+                        logger.warning(
+                            f"Possible adjustment failure: BONUS - {sym} - {purpose} - exDate: {dtStr}"
+                        )
                         continue
 
                     commit = makeAdjustment(

--- a/src/defs/diagnostic.py
+++ b/src/defs/diagnostic.py
@@ -76,13 +76,9 @@ def printResult():
 
 daily = DIR / "eod2_data" / "daily"
 
-dtypeMismatchText = (
-    "{}: Column type Mismatch in {}. Expected float64 or int64. Got {}"
-)
+dtypeMismatchText = "{}: Column type Mismatch in {}. Expected float64 or int64. Got {}"
 columnMismatchText = "{}: Column Length Mismatch. Expect {} got {}"
-indexMismatchText = (
-    "{}: Pandas Index type Mismatch. Expect datetime64[ns] got {}"
-)
+indexMismatchText = "{}: Pandas Index type Mismatch. Expect datetime64[ns] got {}"
 hasNansText = "{}: Column {} has NAN values"
 
 for file in daily.iterdir():

--- a/src/defs/diagnostic.py
+++ b/src/defs/diagnostic.py
@@ -85,24 +85,22 @@ indexMismatchText = (
 )
 hasNansText = "{}: Column {} has NAN values"
 
-for child in daily.iterdir():
+for file in daily.iterdir():
     try:
-        df = pd.read_csv(child, index_col="Date", parse_dates=True)
+        df = pd.read_csv(file, index_col="Date", parse_dates=True)
     except Exception as e:
         # Catch pandas or file parsing errors
-        exceptionsList.append(f"{child.name.upper()}: {e!r}")
+        exceptionsList.append(f"{file.name.upper()}: {e!r}")
         continue
 
     # File is empty or only has column headings
     if df.shape[0] < 1:
-        print(f"daily/{child.name} is empty.")
+        print(f"daily/{file.name} is empty.")
         continue
 
     # Catch Type errors in Datetime index
     if df.index.dtype != "datetime64[ns]":
-        txt = indexMismatchText.format(
-            child.name.upper().ljust(15), df.index.dtype
-        )
+        txt = indexMismatchText.format(file.name.upper().ljust(15), df.index.dtype)
 
         indexMismatchList.append(txt)
 
@@ -111,9 +109,7 @@ for child in daily.iterdir():
 
     # Catch column length errors
     if colLength != 8:
-        txt = columnMismatchText.format(
-            child.name.upper().ljust(15), 5, colLength
-        )
+        txt = columnMismatchText.format(file.name.upper().ljust(15), 5, colLength)
 
         colMismatchList.append(txt)
 
@@ -121,7 +117,7 @@ for child in daily.iterdir():
     for col in df.columns:
         if df[col].dtype not in ("float64", "int64"):
             txt = dtypeMismatchText.format(
-                child.name.upper().ljust(15), col, df[col].dtype
+                file.name.upper().ljust(15), col, df[col].dtype
             )
 
             typeMismatchList.append(txt)
@@ -131,10 +127,11 @@ for child in daily.iterdir():
             hasNansList.append(
                 hasNansText.format(child.name.upper().ljust(15), col)
             )
+            hasNansList.append(hasNansText.format(file.name.upper().ljust(15), col))
 
     # Catch duplicate entries in file
     if df.index.has_duplicates:
-        duplicatesList.append(child.name.upper())
+        duplicatesList.append(file.name.upper())
 
     if getErrorCount() >= ERROR_THRESHOLD:
         break

--- a/src/defs/diagnostic.py
+++ b/src/defs/diagnostic.py
@@ -124,9 +124,11 @@ for file in daily.iterdir():
 
     for col in ("Open", "High", "Low", "Close", "Volume"):
         if df[col].hasnans:
-            hasNansList.append(
-                hasNansText.format(child.name.upper().ljust(15), col)
-            )
+            # Only indices have spaces in file names - bit of a cheat
+            # For indices we only check the Close values for Nan
+            if (" " in file.name) and col != "Close":
+                continue
+
             hasNansList.append(hasNansText.format(file.name.upper().ljust(15), col))
 
     # Catch duplicate entries in file

--- a/src/init.py
+++ b/src/init.py
@@ -17,6 +17,18 @@ if not defs.version_checker(NSE.__version__, major=1, minor=2, patch=4):
     logger.warning("Require NSE version 1.2.4. Run `pip install -U nse`")
     exit()
 
+data_version = defs.meta.get("data-version", None)
+
+if data_version != defs.config.EXPECTED_DATA_VERSION:
+    if (defs.DIR.parent / ".git").exists():
+        print(
+            "eod2_data folder needs an update. Follow instructions at the below link to update:"
+        )
+        print(
+            "https://github.com/BennyThadikaran/eod2/wiki/Installation#updating-the-git-repo\n"
+        )
+    else:
+        print(f"Run `setup_data.py` to update")
 
 # Set the sys.excepthook to the custom exception handler
 sys.excepthook = defs.log_unhandled_exception
@@ -36,7 +48,9 @@ group.add_argument(
 args = parser.parse_args()
 
 if args.version:
-    exit(f"EOD2 init.py: version {defs.config.VERSION}")
+    exit(
+        f"EOD2 init.py: v{defs.config.VERSION} | eod2_data: v{defs.meta.get('data-version', None)}"
+    )
 
 if args.config:
     exit(str(defs.config))


### PR DESCRIPTION
Changelog v8.2.0

- Fixed missing split / bonus adjustments prior to 2011.
- See GH issue #262 (Split not adjusted in jmfinancil.csv) for details

d6edf67ce Feat: track changes/corrections to eod2_data via data-version

- eod2_data folder now has a data-version in meta.json. 
- It allows users to track changes and correction made to eod2_data. 
- On running, script checks if the data-version and notifies the user to update.

729fbdc86 Added check for special bonus shares not requiring adjustment

- See GH issue #264 (TVSMOTORS incorrect adjustment for details).

- Checks for Non convertible preference shares and Differential Voting rights shares issued as bonus

926af799f Added warnings when bonus or split is detected, but adjustment factor is None

7d202c6fa Replace NaN values in Open, High, Low with Close price for Indices

- Some indices only have the Close price and Open, High, Low was only recently added.

- Earlier the missing values are replaced with zero, which can skew moving averages or other technical calculations.

- With the missing values now replaced with empty strings, pandas will treat them as NaNs, while preserving numeric datatype of the columns.

ae40ead2b For Indices, only check Close price for NaN values.

- Data-version v1 uses empty strings instead of 0 for missing values in Open, High and Low for Indices.

c965fbbce Updated eod2_data submodule