### PR TITLE
Dev v9.4.3

### DIFF
--- a/src/defs/config.py
+++ b/src/defs/config.py
@@ -86,7 +86,7 @@ class Config:
     PRESET: dict[str, Any] = field(default_factory=dict)
 
     # ---------- INTERNAL ----------
-    VERSION: str = "9.4.2"
+    VERSION: str = "9.4.3"
     EXPECTED_DATA_VERSION: float = 3.4
 
     @classmethod

--- a/src/renderer/annotations.py
+++ b/src/renderer/annotations.py
@@ -365,6 +365,7 @@ class DrawingManager:
         self._drawings: dict[str, dict[str, Drawing]] = {}
         self._artists: dict[str, dict[str, Artist]] = {}  # Track matplotlib artists
         self.updated = False
+        self.drawings_loaded = False
 
         self.line_args = dict(
             linewidth=1,
@@ -593,3 +594,5 @@ class DrawingManager:
                     color=d["color"],
                     url=d["url"],
                 )
+
+        self.drawings_loaded = True

--- a/src/renderer/annotations.py
+++ b/src/renderer/annotations.py
@@ -364,6 +364,7 @@ class DrawingManager:
         self._ax: Axes | None = None
         self._drawings: dict[str, dict[str, Drawing]] = {}
         self._artists: dict[str, dict[str, Artist]] = {}  # Track matplotlib artists
+        self.updated = False
 
         self.line_args = dict(
             linewidth=1,
@@ -424,6 +425,7 @@ class DrawingManager:
 
         url = drawing.url
         self._drawings[symbol][url] = drawing
+        self.updated = True
 
         # Immediately draw on the axes if available
         if self._ax is not None:
@@ -449,6 +451,11 @@ class DrawingManager:
 
         self._drawings[symbol].pop(url)
 
+        if not self._drawings[symbol]:
+            self._drawings.pop(symbol)
+
+        self.updated = True
+
         if self._ax is not None:
             self._ax.figure.canvas.draw_idle()
 
@@ -466,6 +473,8 @@ class DrawingManager:
         del self._artists[symbol]
 
         del self._drawings[symbol]
+
+        self.updated = True
 
         if self._ax is not None:
             self._ax.figure.canvas.draw_idle()

--- a/src/renderer/coordinator.py
+++ b/src/renderer/coordinator.py
@@ -174,7 +174,9 @@ class PlotCoordinator:
             if self.drawing_manager and self.session_store:
                 index = cast(pd.DatetimeIndex, df.index)
                 self.drawing_manager.set_index(index)
-                self.drawing_manager.from_dict(self.session_store.load_drawings())
+
+                if not self.drawing_manager.drawings_loaded:
+                    self.drawing_manager.from_dict(self.session_store.load_drawings())
         else:
             df = self.loader.load_breadth_indicators()
 

--- a/src/renderer/coordinator.py
+++ b/src/renderer/coordinator.py
@@ -319,7 +319,7 @@ class PlotCoordinator:
             self._show_current()
         else:
             print("No valid symbols to display")
-            self._close_all()
+            self.quit()
 
     def navigate_next(self) -> None:
         """Navigate to the next symbol."""

--- a/src/renderer/coordinator.py
+++ b/src/renderer/coordinator.py
@@ -94,6 +94,15 @@ class PlotCoordinator:
             if not self.indicator_pipeline:
                 raise RuntimeError("IndicatorPipeline not set")
 
+            if (
+                self.drawing_manager
+                and self.session_store
+                and self.drawing_manager.updated
+            ):
+                drawings_data = self.drawing_manager.to_dict()
+                self.session_store.save_drawings(drawings_data)
+                self.drawing_manager.updated = False
+
             symbol, _, meta = symbol.partition(",")
             visited = symbol in self.visited
 


### PR DESCRIPTION
## Release Notes — 9.4.3

### Fixes

* **Prevent loss of chart drawings:** Drawing changes are now saved when switching between charts, so newly added or removed drawings are no longer lost.
* **Avoid reloading drawings:** Drawings are now loaded only once per session instead of being reloaded every time you switch charts.
* **Improve session state saving:** Chart state, selections, and watchlist resume information are now saved correctly even when the last symbol fails to load.

### Data

* Updated market data through **14 August 2026**.