### PR TITLE
Dev v9.4.5

### DIFF
--- a/src/defs/config.py
+++ b/src/defs/config.py
@@ -86,7 +86,7 @@ class Config:
     PRESET: dict[str, Any] = field(default_factory=dict)
 
     # ---------- INTERNAL ----------
-    VERSION: str = "9.4.4"
+    VERSION: str = "9.4.5"
     EXPECTED_DATA_VERSION: float = 3.4
 
     @classmethod

--- a/src/market_breadth_sync.py
+++ b/src/market_breadth_sync.py
@@ -97,13 +97,6 @@ dates = Dates(meta["market_breadth_last_update"])
 
 eod2_last_updated = datetime.fromisoformat(meta["lastUpdate"])
 
-# Date guard - don't sync beyond EOD2 last update
-if dates.lastUpdate >= eod2_last_updated:
-    if eod2_last_updated.replace(tzinfo=None) < dates.today:
-        logger.info("Make sure EOD2 data is synced, before running.")
-    logger.info("All upto date")
-    exit()
-
 try:
     nse = NSE(DIR, server=True)
 except (TimeoutError, ConnectionError, ConnectError) as e:
@@ -133,6 +126,12 @@ while True:
 
         if modified:
             mb_df.to_csv(MARKET_TRACKER_FILE)
+        exit()
+
+    # Date guard - don't sync beyond EOD2 last update
+    if dates.dt > eod2_last_updated:
+        logger.info("Make sure EOD2 data is synced, before running.")
+        logger.info("All upto date")
         exit()
 
     if checkForHolidays(nse, dates):

--- a/src/market_breadth_sync.py
+++ b/src/market_breadth_sync.py
@@ -59,7 +59,9 @@ def extract_pr_zip(zip_file) -> Optional[pd.DataFrame]:
                 mcap = pd.read_csv(
                     f,
                     index_col="Symbol",
-                    usecols=pd.Index(["Symbol", "Series", "Category"]),
+                    usecols=pd.Index(
+                        ["Symbol", "Series", "Category", "Last Trade Date"]
+                    ),
                 )
 
                 mcap.columns = mcap.columns.str.strip()
@@ -180,7 +182,13 @@ while True:
     logger.info("Calculating Indicator values")
 
     for symbol in mcap.index:
+        symbol_original = symbol
         symbol = tracker.get_last_symbol(symbol, by="symbol")
+
+        if symbol is None:
+            last_trade_date = mcap.at[symbol_original, "Last Trade Date"]
+            logger.warning(f"Unable to track {symbol_original} - {last_trade_date}")
+            continue
 
         df = load_symbol(symbol)
 


### PR DESCRIPTION
Version 9.4.5

Fix market breadth sync when a symbol was not traded for the day.
Prevent market breadth sync from running before EOD2 data sync.