### PR TITLE
Dev v9.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fast-csv-loader==2.2.2
 mplfinance==0.12.10b0
-nse[server]==3.1.2
+nse[server]==4.0.1
 pandas==2.0.3; python_version == "3.8"
 pandas==2.2.2; python_version > "3.8" and python_version < "3.13"
 pandas==2.2.3; python_version >= "3.13" and python_version < "3.14"

--- a/src/chart.py
+++ b/src/chart.py
@@ -65,6 +65,10 @@ def run_chart(cmd, paths: AppPaths) -> int:
     cli.validate_file(paths.breadth_file)
     sym_list = cli.resolve_symbols(cmd)
 
+    if not sym_list:
+        print("WARN: Watch file is empty. No symbols to display")
+        return 1
+
     if cmd.source.mode == "stock":
         context = build_stock_context(cmd, paths)
     else:

--- a/src/data/sectors.csv
+++ b/src/data/sectors.csv
@@ -1,6 +1,8 @@
 Nifty 50
-Nifty Midcap 100
-Nifty Smallcap 100
+Nifty Next 50
+Nifty Midcap 150
+Nifty Smallcap 250
+Nifty Microcap 250
 Nifty Bank
 Nifty Private Bank
 Nifty PSU Bank

--- a/src/init.py
+++ b/src/init.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
-if not defs.is_version_compatible(NSE.__version__, major=3, minor=1, patch=2):
-    logger.warning("Require NSE version 3.1.*. Run `pip install 'nse[server]==3.1.2'`")
+if not defs.is_version_compatible(NSE.__version__, major=4, minor=0, patch=1):
+    logger.warning("Require NSE version 4.0.*. Run `pip install 'nse[server]==4.0.1'`")
     exit(1)
 
 data_version = defs.meta.get("data-version", None)


### PR DESCRIPTION
## Release 9.5.0

This release brings updates to the NSE package and adds fixes to chart.py

## What's Changed


- Updated the nse package from 3.2.1 to 4.0.1.
    - Fixes stale-cookie RemoteProtocolError issues.
    - Resolves GitHub issue #342.
- Updated sectors.csv broad-market indices:
    - Removed Nifty Midcap 100 and Nifty Smallcap 100.
    - Added Nifty Next 50, Nifty Midcap 150, Nifty Smallcap 250, Nifty Microcap 250.
    - Together, these broad indices cover the top 750 NSE stocks by market capitalization.
- chart.py now exits with a warning when the watch file is empty.

- Updated the eod2_data submodule.